### PR TITLE
New pull request title skip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Commit skip SCM filters
+# Commit message/author and Pull Request title skip SCM filters
 
 This repository contains a collection of traits for several branch-source Jenkins plugins.
 
@@ -15,3 +15,10 @@ The filtering will be performed, applying it whether it:
 The commit message contains behavior is configurable to additional strings besides the
 defaults provided by the plugin. The strings are treated as literal strings for the
 contains option.
+
+Pull Request title filtering is provided to support skipping CI builds for Pull Requests
+when the title matches a provided pattern. The default patterns matching are `[no test]`,
+`[notest]` and `[no_test]` all case-insensitive.
+
+The Pull Request title filtering is only supported for the Bitbucket Branch Source plugin at
+this time.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It provides filters for both pull requests and/or branches on jobs created from 
 
 The filtering will be performed, applying it whether it:
 
-- The last commit message contains "[skip ci]" or "[ci skip]". The check is case-insensitive.
+- The last commit message contains `[skip ci]` or `[ci skip]`. The check is case-insensitive.
 - The last commit message matches a pattern.
 - The last commit author matches a pattern.
+
+The commit message contains behavior is configurable to additional strings besides the
+defaults provided by the plugin. The strings are treated as literal strings for the
+contains option.

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.scm_filter;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceContext;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -26,13 +28,13 @@ public class BitbucketBranchCommitSkipTrait extends BranchCommitSkipTrait {
      * Constructor for stapler.
      */
     @DataBoundConstructor
-    public BitbucketBranchCommitSkipTrait() {
-        super();
+    public BitbucketBranchCommitSkipTrait(@CheckForNull String tokens) {
+        super(tokens);
     }
 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        context.withFilter(new ExcludeBranchCommitSCMHeadFilter());
+        context.withFilter(new ExcludeBranchCommitSCMHeadFilter(getTokens()));
     }
 
     /**
@@ -60,8 +62,12 @@ public class BitbucketBranchCommitSkipTrait extends BranchCommitSkipTrait {
      */
     private static class ExcludeBranchCommitSCMHeadFilter extends ExcludeByMessageSCMHeadFilter {
 
+        public ExcludeBranchCommitSCMHeadFilter(String tokens) {
+            super(tokens);
+        }
+
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest scmSourceRequest, @NonNull SCMHead scmHead) throws IOException, InterruptedException {
+        public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead) throws IOException, InterruptedException {
             if (scmHead instanceof BranchSCMHead) {
                 Iterable<BitbucketBranch> branches = ((BitbucketSCMSourceRequest) scmSourceRequest).getBranches();
                 for (BitbucketBranch branch : branches) {

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitAuthorBranchBuildStrategy.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitAuthorBranchBuildStrategy.java
@@ -10,6 +10,8 @@ import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMRevision;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.TaskListener;
+import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceDescriptor;

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.scm_filter;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceContext;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -26,13 +28,13 @@ public class BitbucketCommitSkipTrait extends CommitSkipTrait {
      * Constructor for stapler.
      */
     @DataBoundConstructor
-    public BitbucketCommitSkipTrait() {
-        super();
+    public BitbucketCommitSkipTrait(@CheckForNull String tokens) {
+        super(tokens);
     }
 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        context.withFilter(new ExcludeCommitPRsSCMHeadFilter());
+        context.withFilter(new ExcludeCommitPRsSCMHeadFilter(getTokens()));
     }
 
     /**
@@ -60,8 +62,12 @@ public class BitbucketCommitSkipTrait extends CommitSkipTrait {
      */
     private static class ExcludeCommitPRsSCMHeadFilter extends ExcludeByMessageSCMHeadFilter {
 
+        public ExcludeCommitPRsSCMHeadFilter(String tokens) {
+            super(tokens);
+        }
+
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest scmSourceRequest, @NonNull SCMHead scmHead) throws IOException, InterruptedException {
+        public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead) throws IOException, InterruptedException {
             if (scmHead instanceof PullRequestSCMHead) {
                 Iterable<BitbucketPullRequest> pulls = ((BitbucketSCMSourceRequest) scmSourceRequest).getPullRequests();
                 for (BitbucketPullRequest pull : pulls) {

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketPullRequestTitleBuildStrategy.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketPullRequestTitleBuildStrategy.java
@@ -1,0 +1,71 @@
+package org.jenkinsci.plugins.scm_filter;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+
+import hudson.Extension;
+import hudson.Util;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
+
+/**
+ * @author avolanis
+ */
+public class BitbucketPullRequestTitleBuildStrategy extends PullRequestTitleBuildStrategy {
+
+    @DataBoundConstructor
+    public BitbucketPullRequestTitleBuildStrategy(String tokens) {
+        super(tokens);
+    }
+
+    @Override
+    protected String getTitle(SCMSource source, SCMHead head) throws CouldNotGetCommitDataException {
+        if (source instanceof BitbucketSCMSource && head instanceof PullRequestSCMHead) {
+            BitbucketApi client = ((BitbucketSCMSource) source).buildBitbucketClient((PullRequestSCMHead) head);
+            try {
+                BitbucketPullRequest pr = client
+                        .getPullRequestById(Integer.valueOf(((PullRequestSCMHead) head).getId()));
+                return Util.fixEmpty(pr.getTitle());
+            } catch (NumberFormatException e) {
+                throw new CouldNotGetCommitDataException("Could not parse pull request ID to integer");
+            } catch (IOException e) {
+                throw new CouldNotGetCommitDataException("Could not fetch pull request information");
+            } catch (InterruptedException e) {
+                throw new CouldNotGetCommitDataException("Could not fetch pull request information");
+            }
+        }
+
+        throw new CouldNotGetCommitDataException(
+                "SCMSource class is not a BitbucketSCMSource or SCMHead class is not a PullRequestSCMHead");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public @Nonnull String getDisplayName() {
+            return PullRequestTitleBuildStrategy.getDisplayName();
+        }
+
+        /**
+         * {@inheritDoc} this is currently never called for organization folders, see
+         * JENKINS-54468
+         */
+        @Override
+        public boolean isApplicable(@Nonnull SCMSourceDescriptor sourceDescriptor) {
+            return BitbucketSCMSource.DescriptorImpl.class.isAssignableFrom(sourceDescriptor.getClass());
+        }
+    }
+}

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketPullRequestTitleSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketPullRequestTitleSkipTrait.java
@@ -1,0 +1,92 @@
+package org.jenkinsci.plugins.scm_filter;
+
+import java.io.IOException;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketGitSCMBuilder;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+
+import hudson.Extension;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.impl.trait.Selection;
+
+/**
+ * @author avolanis
+ */
+public class BitbucketPullRequestTitleSkipTrait extends TitleSkipTrait {
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public BitbucketPullRequestTitleSkipTrait(@CheckForNull String tokens) {
+        super(tokens);
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        context.withFilter(new ExcludeTitlePRsSCMHeadFilter(getTokens()));
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Selection
+    @Symbol("bitbucketTitleSkipTrait")
+    @SuppressWarnings("unused") // instantiated by Jenkins
+    public static class DescriptorImpl extends TitleSkipTraitDescriptorImpl {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return super.getDisplayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isApplicableToBuilder(@Nonnull Class<? extends SCMBuilder> builderClass) {
+            return BitbucketGitSCMBuilder.class.isAssignableFrom(builderClass);
+        }
+    }
+
+    /**
+     * Filter that excludes pull requests according to its title (if it contains [ci
+     * skip] or [skip ci], case insensitive).
+     */
+    public static class ExcludeTitlePRsSCMHeadFilter extends ExcludeByMessageSCMHeadFilter {
+
+        public ExcludeTitlePRsSCMHeadFilter(String tokens) {
+            super(tokens);
+        }
+
+        @Override
+        public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead)
+                throws IOException, InterruptedException {
+            if (scmHead instanceof PullRequestSCMHead) {
+                Iterable<BitbucketPullRequest> pulls = ((BitbucketSCMSourceRequest) scmSourceRequest).getPullRequests();
+                for (BitbucketPullRequest pull : pulls) {
+                    if (pull.getSource().getBranch().getName().equals(scmHead.getName())) {
+                        String title = pull.getTitle();
+                        return super.containsSkipToken(title.toLowerCase());
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/bitbucket-scm-trait-commit-skip/src/test/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitMessageBranchBuildStrategyTest.java
+++ b/bitbucket-scm-trait-commit-skip/src/test/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitMessageBranchBuildStrategyTest.java
@@ -23,7 +23,7 @@ public class BitbucketCommitMessageBranchBuildStrategyTest {
         when(head.getName()).thenReturn("feature/release");
 
         BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
-        assertThat(strategy.isAutomaticBuild(source, head, buildRevision(head), null), equalTo(false));
+        assertThat(strategy.isAutomaticBuild(source, head, buildRevision(head), null, null, null), equalTo(false));
     }
 
     @Test
@@ -34,7 +34,7 @@ public class BitbucketCommitMessageBranchBuildStrategyTest {
         when(head.getName()).thenReturn("feature/release");
         
         BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
-        assertThat(strategy.isAutomaticBuild(source, head, buildRevision(head), null), equalTo(true));
+        assertThat(strategy.isAutomaticBuild(source, head, buildRevision(head), null, null, null), equalTo(true));
     }
 
     private BitbucketGitSCMRevision buildRevision(SCMHead head) {

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.scm_filter;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -26,13 +28,13 @@ public class GitHubBranchCommitSkipTrait extends BranchCommitSkipTrait {
      * Constructor for stapler.
      */
     @DataBoundConstructor
-    public GitHubBranchCommitSkipTrait() {
-        super();
+    public GitHubBranchCommitSkipTrait(@CheckForNull String tokens) {
+        super(tokens);
     }
 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        context.withFilter(new ExcludeBranchCommitSCMHeadFilter());
+        context.withFilter(new ExcludeBranchCommitSCMHeadFilter(getTokens()));
     }
 
     /**
@@ -60,8 +62,12 @@ public class GitHubBranchCommitSkipTrait extends BranchCommitSkipTrait {
      */
     private static class ExcludeBranchCommitSCMHeadFilter extends ExcludeByMessageSCMHeadFilter {
 
+        public ExcludeBranchCommitSCMHeadFilter(String tokens) {
+            super(tokens);
+        }
+
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest scmSourceRequest, @NonNull SCMHead scmHead) throws IOException, InterruptedException {
+        public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead) throws IOException, InterruptedException {
             if (scmHead instanceof BranchSCMHead) {
                 Iterable<GHBranch> branches = ((GitHubSCMSourceRequest) scmSourceRequest).getBranches();
                 for (GHBranch branch : branches) {

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.scm_filter;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -26,13 +28,13 @@ public class GitHubCommitSkipTrait extends CommitSkipTrait {
      * Constructor for stapler.
      */
     @DataBoundConstructor
-    public GitHubCommitSkipTrait() {
-        super();
+    public GitHubCommitSkipTrait(@CheckForNull String tokens) {
+        super(tokens);
     }
 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        context.withFilter(new ExcludeCommitPRsSCMHeadFilter());
+        context.withFilter(new ExcludeCommitPRsSCMHeadFilter(getTokens()));
     }
 
     /**
@@ -60,8 +62,12 @@ public class GitHubCommitSkipTrait extends CommitSkipTrait {
      */
     private static class ExcludeCommitPRsSCMHeadFilter extends ExcludeByMessageSCMHeadFilter {
 
+        public ExcludeCommitPRsSCMHeadFilter(String tokens) {
+            super(tokens);
+        }
+
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest scmSourceRequest, @NonNull SCMHead scmHead) throws IOException, InterruptedException {
+        public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead) throws IOException, InterruptedException {
             if (scmHead instanceof PullRequestSCMHead) {
                 Iterable<GHPullRequest> pulls = ((GitHubSCMSourceRequest) scmSourceRequest).getPullRequests();
                 for (GHPullRequest pull : pulls) {

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubUtils.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubUtils.java
@@ -15,38 +15,38 @@ import jenkins.scm.api.SCMSource;
 
 public final class GitHubUtils {
 
-	private GitHubUtils() {
-		// utils class, no instances
-	}
+    private GitHubUtils() {
+        // utils class, no instances
+    }
 
-	public static GHCommit getCommit(SCMSource source,SCMRevision revision) throws CouldNotGetCommitDataException {
-		String hash = null;
-		if (AbstractGitSCMSource.SCMRevisionImpl.class.isAssignableFrom(revision.getClass())){
-			hash = ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
-		}
-		if (PullRequestSCMRevision.class.isAssignableFrom(revision.getClass())){
-			hash = ((PullRequestSCMRevision) revision).getPullHash();
-		}
-		if (hash == null) {
-			throw new CouldNotGetCommitDataException("Unknown revision class ["+revision.getClass()+"] or null hash");
-		}
+    public static GHCommit getCommit(SCMSource source,SCMRevision revision) throws CouldNotGetCommitDataException {
+        String hash = null;
+        if (AbstractGitSCMSource.SCMRevisionImpl.class.isAssignableFrom(revision.getClass())){
+            hash = ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
+        }
+        if (PullRequestSCMRevision.class.isAssignableFrom(revision.getClass())){
+            hash = ((PullRequestSCMRevision) revision).getPullHash();
+        }
+        if (hash == null) {
+            throw new CouldNotGetCommitDataException("Unknown revision class ["+revision.getClass()+"] or null hash");
+        }
 
-		if (!GitHubSCMSource.class.isAssignableFrom(source.getClass())){
-			throw new IllegalArgumentException("SCM Source ["+source.getClass()+"] is not a GitHubSCMSource ");
-		}
-		GitHubSCMSource ghSource = (GitHubSCMSource) source;
+        if (!GitHubSCMSource.class.isAssignableFrom(source.getClass())){
+            throw new IllegalArgumentException("SCM Source ["+source.getClass()+"] is not a GitHubSCMSource ");
+        }
+        GitHubSCMSource ghSource = (GitHubSCMSource) source;
 
-		GitHub gitHub = null;
-		try {
-			gitHub = Connector.connect(ghSource.getApiUri(), Connector.lookupScanCredentials
-					((Item) ghSource.getOwner(), ghSource.getApiUri(), ghSource.getCredentialsId()));
-			return gitHub.getRepository(ghSource.getRepoOwner()+"/"+ghSource.getRepository()).getCommit(hash);
-		} catch (IOException e){
-			throw new CouldNotGetCommitDataException(e);
-		}
-		finally{
-			Connector.release(gitHub);
-		}
-	}
+        GitHub gitHub = null;
+        try {
+            gitHub = Connector.connect(ghSource.getApiUri(), Connector.lookupScanCredentials
+                    ((Item) ghSource.getOwner(), ghSource.getApiUri(), ghSource.getCredentialsId()));
+            return gitHub.getRepository(ghSource.getRepoOwner()+"/"+ghSource.getRepository()).getCommit(hash);
+        } catch (IOException e){
+            throw new CouldNotGetCommitDataException(e);
+        }
+        finally{
+            Connector.release(gitHub);
+        }
+    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,13 @@
     <properties>
         <revision>0.5.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <bitbucket-branch-source.version>2.2.14</bitbucket-branch-source.version>
-        <github-branch-source.version>2.3.6</github-branch-source.version>
-        <scm-api.version>2.2.8</scm-api.version>
-        <branch-api.version>2.0.20</branch-api.version>
+        <bitbucket-branch-source.version>2.4.4</bitbucket-branch-source.version>
+        <github-branch-source.version>2.4.2</github-branch-source.version>
+        <scm-api.version>2.4.1</scm-api.version>
+        <branch-api.version>2.5.2</branch-api.version>
         <workflow.version>2.5</workflow.version>
         <mockito.version>2.17.0</mockito.version>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>cloudbees-folder</artifactId>
-                <version>6.1.0</version>
+                <version>6.8</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait.java
@@ -9,6 +9,19 @@ import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
  */
 public abstract class BranchCommitSkipTrait extends SCMSourceTrait {
 
+    private final String tokens;
+
+    /**
+     * Constructor for stapler.
+     */
+    public BranchCommitSkipTrait(String tokens) {
+        this.tokens = tokens;
+    }
+
+    public String getTokens() {
+        return tokens;
+    }
+
     @Override
     protected abstract void decorateContext(SCMSourceContext<?, ?> context);
 
@@ -19,7 +32,7 @@ public abstract class BranchCommitSkipTrait extends SCMSourceTrait {
 
         @Override
         public String getDisplayName() {
-            return "Filter branches by commit message";
+            return Messages.BranchCommitSkipTrait_DisplayName();
         }
     }
 }

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitAuthorBranchBuildStrategy.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitAuthorBranchBuildStrategy.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -44,7 +45,8 @@ public abstract class CommitAuthorBranchBuildStrategy extends BranchBuildStrateg
     }
 
     @Override
-    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
+    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision,
+            SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         String author = null;
         try {
             author = getAuthor(source, currRevision);

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitMessageBranchBuildStrategy.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitMessageBranchBuildStrategy.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -44,7 +45,8 @@ public abstract class CommitMessageBranchBuildStrategy extends BranchBuildStrate
     }
 
     @Override
-    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
+    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision,
+            SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         String message = null;
         try {
             message = getMessage(source, currRevision);

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitSkipTrait.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitSkipTrait.java
@@ -9,6 +9,19 @@ import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
  */
 public abstract class CommitSkipTrait extends SCMSourceTrait {
 
+    private final String tokens;
+
+    /**
+     * Constructor for stapler.
+     */
+    protected CommitSkipTrait(String tokens) {
+        this.tokens = tokens;
+    }
+
+    public String getTokens() {
+        return tokens;
+    }
+
     @Override
     protected abstract void decorateContext(SCMSourceContext<?, ?> context);
 
@@ -19,7 +32,7 @@ public abstract class CommitSkipTrait extends SCMSourceTrait {
 
         @Override
         public String getDisplayName() {
-            return "Filter pull requests by commit message";
+            return Messages.CommitSkipTrait_DisplayName();
         }
     }
 }

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/ExcludeByMessageSCMHeadFilter.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/ExcludeByMessageSCMHeadFilter.java
@@ -1,11 +1,12 @@
 package org.jenkinsci.plugins.scm_filter;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMHeadFilter;
 import jenkins.scm.api.trait.SCMSourceRequest;
-
-import java.io.IOException;
 
 /**
  * Filter that excludes pull requests according to its last commit message (if it contains [ci skip] or [skip ci], case insensitive).
@@ -14,10 +15,16 @@ import java.io.IOException;
  */
 abstract class ExcludeByMessageSCMHeadFilter extends SCMHeadFilter {
 
+    private final TokenListMatcher matcher;
+
+    public ExcludeByMessageSCMHeadFilter(String tokens) {
+        matcher = new TokenListMatcher(tokens);
+    }
+
     @Override
-    abstract public boolean isExcluded(@NonNull SCMSourceRequest scmSourceRequest, @NonNull SCMHead scmHead) throws IOException, InterruptedException;
+    abstract public boolean isExcluded(@Nonnull SCMSourceRequest scmSourceRequest, @Nonnull SCMHead scmHead) throws IOException, InterruptedException;
 
     boolean containsSkipToken(String commitMsg) {
-        return commitMsg.contains("[ci skip]") || commitMsg.contains("[skip ci]");
+        return matcher.containsSkipToken(commitMsg);
     }
 }

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.scm_filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -40,7 +41,7 @@ public abstract class PullRequestTitleBuildStrategy extends BranchBuildStrategy 
 
     @Override
     public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision,
-            SCMRevision prevRevision) {
+            SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         if (!(head instanceof ChangeRequestSCMHead)) {
             return false;
         }

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy.java
@@ -1,0 +1,74 @@
+package org.jenkinsci.plugins.scm_filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+
+public abstract class PullRequestTitleBuildStrategy extends BranchBuildStrategy {
+    private final static Logger LOGGER = LoggerFactory.getLogger(PullRequestTitleBuildStrategy.class);
+
+    public static String getDisplayName() {
+        return Messages.PullRequestTitleBranchBuildStrategy_DisplayName();
+    }
+
+    private final String tokens;
+
+    public PullRequestTitleBuildStrategy(String tokens) {
+        this.tokens = tokens;
+    }
+
+    public String getTokens() {
+        return tokens;
+    }
+
+    private transient TokenListMatcher matcher;
+
+    private boolean containsSkipToken(String title) {
+        if (matcher == null) {
+            matcher = new TokenListMatcher(getTokens());
+        }
+        return matcher.containsSkipToken(title);
+    }
+
+    protected abstract String getTitle(SCMSource source, SCMHead head) throws CouldNotGetCommitDataException;
+
+    @Override
+    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision,
+            SCMRevision prevRevision) {
+        if (!(head instanceof ChangeRequestSCMHead)) {
+            return false;
+        }
+        String title = null;
+        try {
+            title = getTitle(source, head);
+        } catch (CouldNotGetCommitDataException e) {
+            LOGGER.error("Could not attempt to prevent automatic build by pull request title "
+                    + "because of an error when fetching the pull request", e);
+            return true;
+        }
+        if (title == null) {
+            LOGGER.info(
+                    "Could not attempt to prevent automatic build by by pull request title " + "because title is null");
+            return true;
+        }
+        title = title.toLowerCase();
+        if (containsSkipToken(title)) {
+            String ownerDisplayName = "Global";
+            SCMSourceOwner owner = source.getOwner();
+            if (owner != null) {
+                ownerDisplayName = owner.getDisplayName();
+            }
+            LOGGER.info(
+                    "Automatic build prevented for job [{}] because pull request title [{}] " + "contained one of [{}]",
+                    ownerDisplayName, title, tokens);
+            return false;
+        }
+        return true;
+    }
+}

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/RegexFilterBranchBuildStrategyDescriptor.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/RegexFilterBranchBuildStrategyDescriptor.java
@@ -10,15 +10,15 @@ import hudson.util.FormValidation;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 
 public class RegexFilterBranchBuildStrategyDescriptor extends BranchBuildStrategyDescriptor {
-	public FormValidation doCheckPattern(@QueryParameter String value) {
-		if (StringUtils.isBlank(value)) {
-			return FormValidation.error("Cannot be empty");
-		}
-		try {
-			Pattern.compile(value);
-		} catch (PatternSyntaxException e){
-			return FormValidation.error("Regex syntax error: "+e.getMessage());
-		}
-		return FormValidation.ok();
-	}
+    public FormValidation doCheckPattern(@QueryParameter String value) {
+        if (StringUtils.isBlank(value)) {
+            return FormValidation.error("Cannot be empty");
+        }
+        try {
+            Pattern.compile(value);
+        } catch (PatternSyntaxException e){
+            return FormValidation.error("Regex syntax error: "+e.getMessage());
+        }
+        return FormValidation.ok();
+    }
 }

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/TitleSkipTrait.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/TitleSkipTrait.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.scm_filter;
+
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+
+/**
+ * @author avolanis
+ */
+public abstract class TitleSkipTrait extends CommitSkipTrait {
+
+    protected TitleSkipTrait(String tokens) {
+        super(tokens);
+    }
+
+    /**
+     * Our descriptor.
+     */
+    public abstract static class TitleSkipTraitDescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.TitleSkipTrait_DisplayName();
+        }
+    }
+}

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/TokenListMatcher.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/TokenListMatcher.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.scm_filter;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TokenListMatcher {
+    private final Set<String> tokenList;
+
+    public TokenListMatcher(String tokens) {
+        Set<String> list = new HashSet<String>();
+        for (String token : tokens.split(",")) {
+            token = token.trim().toLowerCase();
+            if (!token.isEmpty()) {
+                list.add(token);
+            }
+        }
+        tokenList = Collections.unmodifiableSet(list);
+    }
+
+    public boolean containsSkipToken(String commitMsg) {
+        for (String token : tokenList) {
+            if (commitMsg.contains(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/config.jelly
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/config.jelly
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" />
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Tokens}" field="tokens">
+        <f:textbox default="[ci skip],[skip ci]" />
+    </f:entry>
+</j:jelly>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help-tokens.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help-tokens.html
@@ -1,0 +1,3 @@
+<div>
+    A comma-separated list of tokens to match against in the commit message. Example : [ci skip],[skip ci]
+</div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help.html
@@ -1,3 +1,3 @@
 <div>
-    Branches whose last commit's message contains (case insensitive) the pattern "[ci skip]" or "[skip ci]" will be ignored.
+    Branches whose last commit's message contains (case insensitive) the configured pattern will be ignored. Default patterns: "[ci skip]" or "[skip ci]"
 </div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/config.jelly
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/config.jelly
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" />
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Tokens}" field="tokens">
+        <f:textbox default="[ci skip],[skip ci]" />
+    </f:entry>
+</j:jelly>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help-tokens.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help-tokens.html
@@ -1,0 +1,3 @@
+<div>
+    A comma-separated list of tokens to match against in the commit message. Example : [ci skip],[skip ci]
+</div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help.html
@@ -1,3 +1,3 @@
 <div>
-    Pull requests whose last commit's message contains (case insensitive) the pattern "[ci skip]" or "[skip ci]" will be ignored.
+    Pull requests whose last commit's message contains (case insensitive) the configured pattern will be ignored. Default patterns: "[ci skip]" or "[skip ci]"
 </div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/Messages.properties
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/Messages.properties
@@ -1,4 +1,6 @@
 CommitMessageBranchBuildStrategy.DisplayName=Skip build trigger if commit message contains
 CommitAuthorBranchBuildStrategy.DisplayName=Skip build trigger if commit author contains
+PullRequestTitleBranchBuildStrategy.DisplayName=Skip build trigger if pull request title contains
 BranchCommitSkipTrait.DisplayName=Filter branches by commit message
 CommitSkipTrait.DisplayName=Filter pull requests by commit message
+TitleSkipTrait.DisplayName=Filter pull requests by pull request title

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/Messages.properties
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/Messages.properties
@@ -1,2 +1,4 @@
 CommitMessageBranchBuildStrategy.DisplayName=Skip build trigger if commit message contains
 CommitAuthorBranchBuildStrategy.DisplayName=Skip build trigger if commit author contains
+BranchCommitSkipTrait.DisplayName=Filter branches by commit message
+CommitSkipTrait.DisplayName=Filter pull requests by commit message

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/config.jelly
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/config.jelly
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Tokens}" field="tokens">
+		<f:textbox default="[no test],[notest],[no_test]" />
+	</f:entry>
+</j:jelly>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/help-tokens.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/help-tokens.html
@@ -1,0 +1,3 @@
+<div>
+    A comma-separated list of tokens to search in the title content match. Example : [no test],[no_test]
+</div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/PullRequestTitleBuildStrategy/help.html
@@ -1,0 +1,3 @@
+<div>
+    Pull requests whose title contains (case insensitive) the configured pattern will be ignored. Default patterns: "[no test]", "[notest]" or "[no_test]"
+</div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/config.jelly
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/config.jelly
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Tokens}" field="tokens">
+		<f:textbox default="[no test],[notest],[no_test]" />
+	</f:entry>
+</j:jelly>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/help-tokens.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/help-tokens.html
@@ -1,0 +1,3 @@
+<div>
+    A comma-separated list of tokens to search in the title content match. Example : [no test],[no_test]
+</div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/TitleSkipTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Pull requests whose title contains (case insensitive) the configured pattern will be ignored. Default patterns: "[no test]", "[notest]" or "[no_test]"
+</div>


### PR DESCRIPTION
This feature was implemented for our CI and became quite popular with our developers. We are contributing this to promote it and help share with the community.

Currently we are using this new Pull Request title skip feature with Bitbucket and as such we did not implement the equivalent for Github. I have not tried to find the equivalent API to make the same work with Github, if someone can suggest the API to use for this I can work to add the same feature for Github.

Additionally this change adds a configurable list of strings to the commit contains option with defaults that match the original hard-coded list of strings.
