### PR TITLE
Add Symbols for Build Strategies

### DIFF
--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitAuthorBranchBuildStrategy.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitAuthorBranchBuildStrategy.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.scm_filter;
 
 import javax.annotation.Nonnull;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketGitSCMRevision;
@@ -37,6 +38,7 @@ public class BitbucketCommitAuthorBranchBuildStrategy extends CommitAuthorBranch
     }
 
     @Extension
+    @Symbol("bitbucketCommitAuthorBranchBuildStrategy")
     public static class DescriptorImpl extends RegexFilterBranchBuildStrategyDescriptor {
 
         @Override

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitMessageBranchBuildStrategy.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitMessageBranchBuildStrategy.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.scm_filter;
 
 import javax.annotation.Nonnull;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketGitSCMRevision;
@@ -37,6 +38,7 @@ public class BitbucketCommitMessageBranchBuildStrategy extends CommitMessageBran
     }
 
     @Extension
+    @Symbol("bitbucketCommitMessageBranchBuildStrategy")
     public static class DescriptorImpl extends RegexFilterBranchBuildStrategyDescriptor {
 
         @Override

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitAuthorBranchBuildStrategy.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitAuthorBranchBuildStrategy.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,6 +34,7 @@ public class GitHubCommitAuthorBranchBuildStrategy extends CommitAuthorBranchBui
     }
 
     @Extension
+    @Symbol("gitHubCommitAuthorBranchBuildStrategy")
     public static class DescriptorImpl extends RegexFilterBranchBuildStrategyDescriptor {
 
         @Override

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitMessageBranchBuildStrategy.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitMessageBranchBuildStrategy.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,6 +34,7 @@ public class GitHubCommitMessageBranchBuildStrategy extends CommitMessageBranchB
     }
 
     @Extension
+    @Symbol("gitHubCommitMessageBranchBuildStrategy")
     public static class DescriptorImpl extends RegexFilterBranchBuildStrategyDescriptor {
 
         @Override


### PR DESCRIPTION
Job DSL can't currently populate build strategies from this plugin because they are missing symbols; a quick fix can be done to add the symbols for ease of use. The symbols already existed for the traits, they were just missing from the strategies.

### Testing done
- Added strategy to job DSL config and confirmed that proper DSL was generated
- Confirmed that Job DSL plugin page showed correct build strategies in the generated api viewer 

<img width="893" alt="image" src="https://github.com/user-attachments/assets/793dcc70-4ae1-4100-86ab-32e9b7b90a86" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue